### PR TITLE
Added Prerequisite: Daily-Closing

### DIFF
--- a/doc/appendix-de-kassensichv/procedural-documentation/dsfinv-k-generation.md
+++ b/doc/appendix-de-kassensichv/procedural-documentation/dsfinv-k-generation.md
@@ -7,9 +7,14 @@ title: DSFinV-K generation
 
 ## DSFinV-K export
 
-The fiskaltrust.Middleware is able to automatically generate a DSFinV-K export, either via the `journal` endpoint (locally) or in the cloud (when a POS Archive was purchased). Based on the version 2.2 of the DSFinV-K specification, this chapter explains how the DSFinV-K export is structured, shows how the previously described input values are mapped by fiskaltrust to the files and data of the DSFinV-K export and defines how additional, for the DSFInV-K required, values can be sent to the ft.Middleware. Furthermore, it describes how the marking of actions (DE: Vorgänge) can be made by connecting business actions (DE: Geschäftsvorfälle) and other procedures, occurrences and events (DE: Andere Vorgänge). 
+The fiskaltrust.Middleware is able to automatically generate a DSFinV-K export, either via the `journal` endpoint (locally) or in the cloud (when a POS Archive was purchased).
+Based on the version 2.2 of the DSFinV-K specification, this chapter explains how the DSFinV-K export is structured, shows how the previously described input values are mapped by fiskaltrust to the files and data of the DSFinV-K export and defines how additional, for the DSFInV-K required, values can be sent to the ft.Middleware. Furthermore, it describes how the marking of actions (DE: Vorgänge) can be made by connecting business actions (DE: Geschäftsvorfälle) and other procedures, occurrences and events (DE: Andere Vorgänge). 
 
 This chapter explains how the DSFinV-K export, based on version 2.2 of the DSFinV-K specification, is structured. It describes how the previously described input values are mapped by fiskaltrust to the files and data of the DSFinV-K export. It defines how additional, for the DSFinV-K required values, can be sent to the fiskaltrust.Middleware. Furthermore, it describes how the marking of actions (DE: Vorgänge) can be made by connecting business actions (DE: Geschäftsvorfälle) and other procedures, occurrences and events (DE: Andere Vorgänge). 
+
+### Prerequisite
+
+A daily-closing-receipt must be sent at the end of the day for the fiskaltrust.Middleware to be able to generate the DSFinV-K export. Without the daily-closing-receipts the DFinV-K export will be empty.
 
 ### Structure
 


### PR DESCRIPTION
We start to notice more and more customers can't export the DSFinV-K because they have never done a daily-closing. Currently it's only mentioned in the postman middleware samples that a daily-closing is mandatory for the DSFinV-K export. https://middleware-samples.docs.fiskaltrust.cloud/#6e241154-0e76-4bd0-b00d-4471415e6a76