### PR TITLE
warning cbPreviousReceiptReference maximum length

### DIFF
--- a/doc/middleware-de-kassensichv/data-structures/data-structures.md
+++ b/doc/middleware-de-kassensichv/data-structures/data-structures.md
@@ -24,6 +24,12 @@ Fields from the receipt request that need special handling for the German market
 
 Examples of using `cbReceiptReference` and `cbPreviousReceiptReference` to connect requests representing a business action can be found in our Postman collection.
 
+:::caution
+
+If using `cbPreviousReceiptReference`, as per DSFinV-K it must have a maximum length of 50 characters. Exceeding this length will result in export errors (e.g., DATEV MeinFiskal).
+
+:::
+
 #### Customer data `cbCustomer`
 
 If you need to provide customer data in your request, you can send it in via the field `cbCustomer` by filling it JSON format with following fields:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo! -->

<!-- If this is your first PR to one of fiskaltrust's repos, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/fiskaltrust/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/fiskaltrust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

{Summary of the changes}

## Description

As per DFKA Taxonomy the parameter cbPreviousReceiptReference must not be longer than 50 characters. 

Fixes #55407
