### PR TITLE
Fixed Position cancellation flag in docs

### DIFF
--- a/doc/middleware-de-kassensichv/reference-tables/type-of-payment-ftpayitemcase.md
+++ b/doc/middleware-de-kassensichv/reference-tables/type-of-payment-ftpayitemcase.md
@@ -42,4 +42,4 @@ This table shows flags that can be added to each `ftPayItemCase` with values app
 |---|---|---|
 | 0x0000000000200000<sup>1</sup> | **Position cancellation flag** <br />When this flag is sent: Only the amount is used for calculating the sums in the Middleware, the DSFinV-K and the DFKA (instead of our common approach with the Quantity-based calculation). Sets the STORNO field in the DSFinV-K and the DFKA | 1.3.1- |
 
-<sup>1</sup> Previous documentation contained a typo regarding this flag. The documentation has been corrected to align with the middleware implementation.
+<sup>1</sup> Previous documentation contained a typo regarding this flag. The documentation has been corrected to align with the [middleware implementation](https://docs.fiskaltrust.eu/changelog/middleware/1.3.66#-feature-support-line-cancellations).

--- a/doc/middleware-de-kassensichv/reference-tables/type-of-service-ftchargeitemcase.md
+++ b/doc/middleware-de-kassensichv/reference-tables/type-of-service-ftchargeitemcase.md
@@ -140,7 +140,7 @@ This table shows flags that can be added to each `ftChargeItemCase` with values 
 | 0x0000000000010000 | **Take away marker.** <br />For some cases, it is necessary to differ for the same good from in-house-consumption and take away. This flag signals a take away situation or in other words, a not-in-house-consumption if it is set. | 1.3.1- |
 | 0x0000000000200000<sup>1</sup> | **Position cancellation flag** <br />When this flag is sent: Only the amount is used for calculating the sums in the Middleware, the DSFinV-K and the DFKA (instead of our common approach with the Quantity-based calculation). Sets the STORNO field in the DSFinV-K and the DFKA | 1.3.1- |
 
-<sup>1</sup> Previous documentation contained a typo regarding this flag. The documentation has been corrected to align with the middleware implementation.
+<sup>1</sup> Previous documentation contained a typo regarding this flag. The documentation has been corrected to align with the [middleware implementation](https://docs.fiskaltrust.eu/changelog/middleware/1.3.66#-feature-support-line-cancellations).
 
 #### Table with vat rate reference numbers defined in DSFinV-K
 


### PR DESCRIPTION
The position cancellation flag has had a typo in the number of zeros. This has been fixed and a note has been added.